### PR TITLE
Issue #1 quick-fix/hack

### DIFF
--- a/DjvuNet/DjvuNet/DjvuPage.cs
+++ b/DjvuNet/DjvuNet/DjvuPage.cs
@@ -879,6 +879,9 @@ namespace DjvuNet
         public System.Drawing.Bitmap BuildPageImage()
         {
             int subsample = 1;
+            if ( this.Info==null && Document.FormChunk.Children[0].ChunkID=="DJVU" && Document.FormChunk.Children[1] is InfoChunk )
+            	this._info = (InfoChunk)Document.FormChunk.Children[1];
+            
             int width = Info.Width / subsample;
             int height = Info.Height / subsample;
 


### PR DESCRIPTION
- prevent load exception on single-file document (Issue #1 temp/partial-fix)
    - added check for 'DJVU'/single-page doc (DjvuDocument.cs)
    - injected InfoChunck if single-page doc (DjvuPage.cs)
- some pages still render black